### PR TITLE
add debug configs for local dev preview

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,41 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Preview Docs (Chrome)",
+            "request": "launch",
+            "runtimeArgs": [
+                "preview"
+            ],
+            "runtimeExecutable": "quarto",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+            "serverReadyAction": {
+                "action": "debugWithChrome",
+                "pattern": "Browse at http://localhost:(\\d+)",
+                "uriFormat": "http://localhost:%s",
+                "killOnServerStop": true
+            }
+        },
+        {
+            "name": "Preview Docs (Edge)",
+            "request": "launch",
+            "runtimeArgs": [
+                "preview"
+            ],
+            "runtimeExecutable": "quarto",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+            "serverReadyAction": {
+                "action": "debugWithEdge",
+                "pattern": "Browse at http://localhost:(\\d+)",
+                "uriFormat": "http://localhost:%s",
+                "killOnServerStop": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Vale runs [via GH action on PRs](https://github.com/posit-dev/positron-website/a
 
 ## Local development
 
-If you have `quarto` and Chrome or Edge installed locally, you can preview the site by running one of the Debug Configurations in VS Code or Positron.
+If you have Quarto and Chrome or Edge installed locally, you can preview the site by running one of the Debug Configurations in VS Code or Positron.
 
 The configurations run `quarto preview` and then open the site in a new browser window.
 - **Preview Docs (Chrome)**: Preview the site in Chrome

--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ This project uses [Vale](https://vale.sh/docs/) for automated linting and compli
 - If you are an external contributor, we as reviewers will take responsibility for compliance with the guidelines. Thank you for being willing to improve our docs!
 
 Vale runs [via GH action on PRs](https://github.com/posit-dev/positron-website/actions/workflows/lint.yml), but you can also run it locally before you submit a PR if you have [installed Vale](https://vale.sh/docs/vale-cli/installation/) locally. Run `vale .` from the root directory of this project to lint the `.qmd` files used to build to site.
+
+## Local development
+
+If you have `quarto` and Chrome or Edge installed locally, you can preview the site by running one of the Debug Configurations in VS Code or Positron.
+
+The configurations run `quarto preview` and then open the site in a new browser window.
+- **Preview Docs (Chrome)**: Preview the site in Chrome
+- **Preview Docs (Edge)**: Preview the site in Edge
+
+The site will re-render as you make changes to the `.qmd` files.


### PR DESCRIPTION
Adds debug configurations to launch the docs site in Chrome or Edge, so that the docs site can be easily previewed when developing locally.

The launch config runs `quarto preview`, waits for the localhost url pattern to be matched, then opens the url in Chrome or Edge depending on which launch configuration was chosen.

<img width="365" alt="image" src="https://github.com/user-attachments/assets/5ed1ea81-bf52-424c-9667-25b466dc497b">
