### PR TITLE
"Current" version of R takes precedence over exact version number

### DIFF
--- a/interpreters.qmd
+++ b/interpreters.qmd
@@ -20,7 +20,13 @@ Positron tries to start R for R users and Python for Python users by checking to
 
 When Positron starts in a workspace that has been used before, it will start the same interpreter (or interpreters, if more than one) that were running the last time that you used that workspace.
 
-If Positron starts an interpreter you don't need, just shut it down (using the Power button in Console or the upper right) and it will stop starting automatically in that workspace. 
+In the case of R, there is an additional subtlety:
+When Positron records which R version was most recently used in a workspace, it also notes whether that R version is the system's current or default R version.
+In subsequent sessions, Positron will launch the system's current R version, even if that has a different version number from the last-used R version.
+We believe this behaviour is the least surprising for most users.
+If you want to use a specific, non-current R version in a workspace, select it explicitly once (more on that below) and it will be launched in future sessions.
+
+If Positron starts an interpreter you don't need, just shut it down (using the Power button in Console or the upper right) and it will stop starting automatically in that workspace.
 
 ## Implicit startup
 


### PR DESCRIPTION
Relates to https://github.com/posit-dev/positron/issues/5222