### PR TITLE
Add advice on Rtools

### DIFF
--- a/start.qmd
+++ b/start.qmd
@@ -28,6 +28,12 @@ Before installing Positron, ensure your Python and/or R environments are ready t
 
 If you're using Windows, make sure you have the [latest Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) installed.
 
+If you're an R user, note that Positron does not currently bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/rtools40.html). If you need Rtools for your package development or other work, you can either use the official guidance from CRAN on installing Rtools and putting it on the path, or alternatively, use [rig](https://github.com/r-lib/rig) to install and set up Rtools:
+
+```shell
+rig system rtools add
+```
+
 ### Python prerequisites
 
 Positron works with [actively supported versions](https://devguide.python.org/versions/#versions) of Python, from 3.8 to Python 3.12. We recommend [pyenv](https://github.com/pyenv/pyenv) and [pyenv for Windows](https://github.com/pyenv-win/pyenv-win) for managing Python versions. On Linux, you'll want to [be aware of the build requirements](https://github.com/pyenv/pyenv/wiki/common-build-problems); for example, you'll need the system library for SQLite (`sqlite-devel` or `libsqlite3-dev`) installed ahead of time so pyenv can properly build your chosen Python version for use with Positron.

--- a/start.qmd
+++ b/start.qmd
@@ -28,7 +28,7 @@ Before installing Positron, ensure your Python and/or R environments are ready t
 
 If you're using Windows, make sure you have the [latest Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) installed.
 
-If you're an R user, note that Positron doesn't currently bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/rtools40.html). If you need Rtools for your package development or other work, you can either use the official guidance from CRAN on installing Rtools and putting it on the path, or alternatively, use [rig](https://github.com/r-lib/rig) to install and set up Rtools:
+If you're an R user, note that Positron doesn't currently bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/). If you need Rtools for your package development or other work, you can either use the official guidance from CRAN on installing Rtools and putting it on the path, or alternatively, use [rig](https://github.com/r-lib/rig) to install and set up Rtools:
 
 ```bash
 rig system rtools add

--- a/start.qmd
+++ b/start.qmd
@@ -28,7 +28,7 @@ Before installing Positron, ensure your Python and/or R environments are ready t
 
 If you're using Windows, make sure you have the [latest Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) installed.
 
-If you're an R user, note that Positron does not currently bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/rtools40.html). If you need Rtools for your package development or other work, you can either use the official guidance from CRAN on installing Rtools and putting it on the path, or alternatively, use [rig](https://github.com/r-lib/rig) to install and set up Rtools:
+If you're an R user, note that Positron doesn't currently bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/rtools40.html). If you need Rtools for your package development or other work, you can either use the official guidance from CRAN on installing Rtools and putting it on the path, or alternatively, use [rig](https://github.com/r-lib/rig) to install and set up Rtools:
 
 ```shell
 rig system rtools add

--- a/start.qmd
+++ b/start.qmd
@@ -30,7 +30,7 @@ If you're using Windows, make sure you have the [latest Visual C++ Redistributab
 
 If you're an R user, note that Positron doesn't currently bundle [Rtools](https://cran.r-project.org/bin/windows/Rtools/rtools40.html). If you need Rtools for your package development or other work, you can either use the official guidance from CRAN on installing Rtools and putting it on the path, or alternatively, use [rig](https://github.com/r-lib/rig) to install and set up Rtools:
 
-```shell
+```bash
 rig system rtools add
 ```
 


### PR DESCRIPTION
For context, Rtools is a Windows requirement for mainly R package developers. Maybe I should more strongly advise toward rig, given how easy it is? I don't feel like we can _only_ tell folks about rig here.

Related to posit-dev/positron/issues/5358 but we will eventually want to do a bit more work in the product itself related to Rtools.