### PR TITLE
Add how to use isPositron context

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -64,6 +64,7 @@ website:
         - connections-pane.qmd
         - run-interactive-apps.qmd
         - updating.qmd
+        - extension-development.qmd
 
     - title: "Help"
       style: "docked"

--- a/extension-development.qmd
+++ b/extension-development.qmd
@@ -6,7 +6,7 @@ Positron is compatible with VS Code extensions so you can create extensions [as 
 
 ## Context keys
 
-When defining your extension's manifest, you can use `isPositron` for enablement or in a `when` clause.
+When defining your extension's manifest, you can use the `isPositron` context key for enablement or in a `when` clause.
 
 ```json
 "commands": [

--- a/extension-development.qmd
+++ b/extension-development.qmd
@@ -2,9 +2,10 @@
 title: "Extension Development"
 ---
 
-When creating an extension, Positron is compatible with VS Code extensions so create it as you would for VS Code.
+Positron is compatible with VS Code extensions so you can create extensions [as you would for VS Code](https://code.visualstudio.com/api/get-started/your-first-extension). You can use Positron to develop your extension and run it in a new **Extension Development Host** window.
 
-## Context Keys
+## Context keys
+
 When defining your extension's manifest, you can use `isPositron` for enablement or in a `when` clause.
 
 ```json
@@ -19,3 +20,7 @@ When defining your extension's manifest, you can use `isPositron` for enablement
 ```
 
 This allows your extension to enable commands, keybindings, menu items, and any other contribution points only for Positron.
+
+## Positron API
+
+Positron provides [all the normal contribution points and the VS Code API](https://code.visualstudio.com/api/extension-capabilities/overview) to extensions, but also additionally new APIs to use. We plan to make the extension development experience better (for example, [safely wrapping](https://github.com/posit-dev/positron/issues/458) and [providing typing for](https://github.com/posit-dev/positron/issues/809) the Positron API), but in the meantime, we recommend you [take a look at the Positron API details directly](https://github.com/posit-dev/positron/tree/main/src/positron-dts).

--- a/extension-development.qmd
+++ b/extension-development.qmd
@@ -1,0 +1,21 @@
+---
+title: "Extension Development"
+---
+
+When creating an extension, Positron is compatible with VS Code extensions so create it as you would for VS Code.
+
+## Context Keys
+When defining your extension's manifest, you can use `isPositron` for enablement or in a `when` clause.
+
+```json
+"commands": [
+    {
+        "category": "My Extension",
+        "command": "myExtension.myCommand",
+        "title": "My Extension Command",
+        "enablement": "isPositron"
+    }
+]
+```
+
+This allows your extension to enable commands, keybindings, menu items, and any other contribution points only for Positron.

--- a/extensions.qmd
+++ b/extensions.qmd
@@ -8,9 +8,11 @@ Since Positron is built on [Code OSS](https://github.com/microsoft/vscode), you 
 Positron doesn't currently bundle the [Shiny](https://open-vsx.org/extension/posit/shiny) extension, so you will need to install that if you want to use it.
 :::
 
+See [Extension Development](extension-development.qmd) for information on creating extensions specifically for Positron.
+
 ### Installing extensions
 
-Positron has an Extensions view, just like VS Code. The primary difference is that when you browse extensions in Positron, the extensions don't come from VS Code's Marketplace. Instead, they come from a third-party marketplace, [OpenVSX](https://open-vsx.org/). This is necessary for licensing reasons; Microsoft doesn't permit access to the Marketplace from non-official clients. 
+Positron has an Extensions view, just like VS Code. The primary difference is that when you browse extensions in Positron, the extensions don't come from VS Code's Marketplace. Instead, they come from a third-party marketplace, [OpenVSX](https://open-vsx.org/). This is necessary for licensing reasons; Microsoft doesn't permit access to the Marketplace from non-official clients.
 
 OpenVSX includes most popular VS Code extensions, but not all; some authors don't bother to publish their extensions to OpenVSX (it's an extra step) and others don't keep the OpenVSX version of the extension up to date. Open VSX has a suggested [template](https://github.com/open-vsx/publish-extensions/blob/master/docs/external_contribution_request.md) to request that the authors of an extension cross-publish their extension on the Open VSX Registry.
 
@@ -35,5 +37,3 @@ if (interactive() && Sys.getenv("RSTUDIO") == "" && Sys.getenv("POSITRON") == ""
 -   [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python): Positron bundles a fork of this extension that's built to work with Positron and offers support for the console, help, and other features. If there is anything from the original Python extension that doesn't work for you, please let us know.
 
 There may be extensions that aren't available for Positron for licensing rather than technical reasons. These extensions would typically contain proprietary Microsoft code and are only licensed for use with Microsoft's proprietary VS Code product.
-
-See [Extension Development](extension-development.qmd) for creating extensions for Positron.

--- a/extensions.qmd
+++ b/extensions.qmd
@@ -8,8 +8,6 @@ Since Positron is built on [Code OSS](https://github.com/microsoft/vscode), you 
 Positron doesn't currently bundle the [Shiny](https://open-vsx.org/extension/posit/shiny) extension, so you will need to install that if you want to use it.
 :::
 
-See [Extension Development](extension-development.qmd) for information on creating extensions specifically for Positron.
-
 ### Installing extensions
 
 Positron has an Extensions view, just like VS Code. The primary difference is that when you browse extensions in Positron, the extensions don't come from VS Code's Marketplace. Instead, they come from a third-party marketplace, [OpenVSX](https://open-vsx.org/). This is necessary for licensing reasons; Microsoft doesn't permit access to the Marketplace from non-official clients.
@@ -37,3 +35,7 @@ if (interactive() && Sys.getenv("RSTUDIO") == "" && Sys.getenv("POSITRON") == ""
 -   [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python): Positron bundles a fork of this extension that's built to work with Positron and offers support for the console, help, and other features. If there is anything from the original Python extension that doesn't work for you, please let us know.
 
 There may be extensions that aren't available for Positron for licensing rather than technical reasons. These extensions would typically contain proprietary Microsoft code and are only licensed for use with Microsoft's proprietary VS Code product.
+
+:::{.callout-tip}
+See [Extension Development](extension-development.qmd) for information on creating extensions specifically for Positron.
+:::

--- a/extensions.qmd
+++ b/extensions.qmd
@@ -35,3 +35,5 @@ if (interactive() && Sys.getenv("RSTUDIO") == "" && Sys.getenv("POSITRON") == ""
 -   [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python): Positron bundles a fork of this extension that's built to work with Positron and offers support for the console, help, and other features. If there is anything from the original Python extension that doesn't work for you, please let us know.
 
 There may be extensions that aren't available for Positron for licensing rather than technical reasons. These extensions would typically contain proprietary Microsoft code and are only licensed for use with Microsoft's proprietary VS Code product.
+
+See [Extension Development](extension-development.qmd) for creating extensions for Positron.


### PR DESCRIPTION
Adds a page on extension development with an example of how one would use `isPositron` in their extension manifest.

Addresses https://github.com/posit-dev/positron/issues/5339