### PR TITLE
Add more prominent link to GitHub repo in navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -45,6 +45,7 @@ website:
         href: troubleshooting.qmd
     right:
       - icon: github
+        aria-label: 'Link to Positron Github Repository'
         href: https://github.com/posit-dev/positron
 
   sidebar:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,6 +43,9 @@ website:
         href: interpreters.qmd
       - text: "Help"
         href: troubleshooting.qmd
+    right:
+      - icon: github
+        href: https://github.com/posit-dev/positron
 
   sidebar:
     - title: "Get Started"


### PR DESCRIPTION
@sharon-wang pointed out that there is not a prominent link to point folks to our GitHub repo from the homepage or top nav.