### PR TITLE
fix typo amd64 --> arm64

### DIFF
--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -19,7 +19,7 @@ end
 
 ## System requirements
 
-Remote SSH sessions can be *initiated* from any operating system supported by Positron itself, including macOS, Linux, and Windows. However, the system you are *connecting* to must be running Linux using a **recent distribution**, such as Ubuntu 22+ or RedHat 9+, on an x86-compatible processor. Older Linux distributions and amd64 hosts aren't currently supported.
+Remote SSH sessions can be *initiated* from any operating system supported by Positron itself, including macOS, Linux, and Windows. However, the system you are *connecting* to must be running Linux using a **recent distribution**, such as Ubuntu 22+ or RedHat 9+, on an x86-compatible processor. Older Linux distributions and arm64 hosts aren't currently supported.
 
 Other features that aren't currently supported include:
 


### PR DESCRIPTION
I think we might mean arm64 here? If this isn't actually a typo, let me know!