### PR TITLE
Add WSL to Remote SSH page

### DIFF
--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -1,10 +1,10 @@
 ---
-title: "Remote SSH and WSL"
+title: "Remote SSH"
 ---
 
-Positron has **experimental** support for Remote SSH sessions. This feature allows the Positron IDE's front end (user interface) to run on one machine, while the back end (files, projects, Python and R sessions, etc.) runs on another machine. The two machines communicate using an ordinary secure shell (SSH) connection.
+Positron has **experimental** support for Remote SSH sessions. This feature allows the Positron IDE's front end (user interface) to run on one machine, while the back end (files, projects, Python and R sessions, etc.) runs on another machine.[^1] The two machines communicate using an ordinary secure shell (SSH) connection.
 
-Although Positron does not officially support connecting to Windows Subsystem for Linux (WSL) backends at this stage, there is an open-source fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension dedicated to Positron maintained by community, available from the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl), that can be used in the meantime while official support is being developed. The community-maintained WSL extension behaves very similarly to the remote SSH functionality.
+[^1]: Although Positron does not officially support connecting to Windows Subsystem for Linux (WSL) backends, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article. This WSL extension is not maintained by the Positron team or Posit.
 
 ```{mermaid}
 %%| fig-align: center

--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -26,7 +26,9 @@ Other features that aren't currently supported include:
 - Connecting to Windows Subsystem for Linux (WSL) backends[^1]
 - Dev Container workflows (note however that you can start a container yourself and connect to it)
 
-[^1]: Although Positron does not officially support connecting to Windows Subsystem for Linux (WSL) backends at this time, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article. This WSL extension is not maintained by the Positron team or Posit.
+<!-- vale Posit.Contractions = NO -->
+[^1]: Although Positron doesn't officially support connecting to Windows Subsystem for Linux (WSL) backends at this time, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article. This WSL extension is not maintained by the Positron team or Posit.
+<!-- vale Posit.Contractions = YES -->
 
 ## Creating a connection
 

--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -2,9 +2,8 @@
 title: "Remote SSH"
 ---
 
-Positron has **experimental** support for Remote SSH sessions. This feature allows the Positron IDE's front end (user interface) to run on one machine, while the back end (files, projects, Python and R sessions, etc.) runs on another machine.[^1] The two machines communicate using an ordinary secure shell (SSH) connection.
+Positron has **experimental** support for Remote SSH sessions. This feature allows the Positron IDE's front end (user interface) to run on one machine, while the back end (files, projects, Python and R sessions, etc.) runs on another machine. The two machines communicate using an ordinary secure shell (SSH) connection.
 
-[^1]: Although Positron does not officially support connecting to Windows Subsystem for Linux (WSL) backends, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article. This WSL extension is not maintained by the Positron team or Posit.
 
 ```{mermaid}
 %%| fig-align: center
@@ -25,7 +24,10 @@ Remote SSH sessions can be *initiated* from any operating system supported by Po
 
 Other features that aren't currently supported include:
 
+- Connecting to Windows Subsystem for Linux (WSL) backends[^1]
 - Dev Container workflows (note however that you can start a container yourself and connect to it)
+
+[^1]: Although Positron does not officially support connecting to Windows Subsystem for Linux (WSL) backends at this time, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article. This WSL extension is not maintained by the Positron team or Posit.
 
 ## Creating a connection
 

--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -4,7 +4,6 @@ title: "Remote SSH"
 
 Positron has **experimental** support for Remote SSH sessions. This feature allows the Positron IDE's front end (user interface) to run on one machine, while the back end (files, projects, Python and R sessions, etc.) runs on another machine. The two machines communicate using an ordinary secure shell (SSH) connection.
 
-
 ```{mermaid}
 %%| fig-align: center
 flowchart LR

--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -1,8 +1,10 @@
 ---
-title: "Remote SSH"
+title: "Remote SSH and WSL"
 ---
 
 Positron has **experimental** support for Remote SSH sessions. This feature allows the Positron IDE's front end (user interface) to run on one machine, while the back end (files, projects, Python and R sessions, etc.) runs on another machine. The two machines communicate using an ordinary secure shell (SSH) connection.
+
+Although Positron does not officially support connecting to Windows Subsystem for Linux (WSL) backends at this stage, there is an open-source fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension dedicated to Positron maintained by community, available from the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl), that can be used in the meantime while official support is being developed. The community-maintained WSL extension behaves very similarly to the remote SSH functionality.
 
 ```{mermaid}
 %%| fig-align: center
@@ -23,7 +25,6 @@ Remote SSH sessions can be *initiated* from any operating system supported by Po
 
 Other features that aren't currently supported include:
 
-- Connecting to Windows Subsystem for Linux (WSL) backends
 - Dev Container workflows (note however that you can start a container yourself and connect to it)
 
 ## Creating a connection

--- a/remote-ssh.qmd
+++ b/remote-ssh.qmd
@@ -26,8 +26,9 @@ Other features that aren't currently supported include:
 - Connecting to Windows Subsystem for Linux (WSL) backends[^1]
 - Dev Container workflows (note however that you can start a container yourself and connect to it)
 
+[^1]: Although Positron doesn't officially support connecting to Windows Subsystem for Linux (WSL) backends at this time, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article.
 <!-- vale Posit.Contractions = NO -->
-[^1]: Although Positron doesn't officially support connecting to Windows Subsystem for Linux (WSL) backends at this time, there is a community-maintained fork of the [Open Remote - WSL](https://github.com/kv9898/open-remote-wsl) extension adapted for Positron, available on the [Open VSX Registry](https://open-vsx.org/extension/kv9898/open-remote-wsl). The community-maintained WSL extension behaves very similarly to the remote SSH functionality described in this article. This WSL extension is not maintained by the Positron team or Posit.
+This WSL extension is not maintained by the Positron team or Posit.
 <!-- vale Posit.Contractions = YES -->
 
 ## Creating a connection


### PR DESCRIPTION
Currently, Positron does not *officially* support connecting to WSL. However, I have built a fork of the Open Remote - WSL extension for Positron and have been using it regularly without known problem. The extension has been downloaded almost 700 times from Open VSX Registry. I therefore think it is worth informing new users of Positron that a community-maintained WSL functionality is available, and they can inspect its source code and use it at their own risk.