### PR TITLE
Update names of output settings, extensions, etc.

### DIFF
--- a/r-installations.qmd
+++ b/r-installations.qmd
@@ -48,7 +48,7 @@ If you have an R installation that won't be discovered by the search strategy de
   - Hypothetical example: `C:/nonstandardRLocation/R-4.4.1/bin/x64/R.exe`
 
 One way to navigate to these settings is to use the command palette to open Preferences: Open Settings.
-Then navigate to **Extensions** > **R** > **Positron R Language Pack (advanced)**.
+Then navigate to **Extensions** > **R** > **Advanced**.
 It's important to use absolute paths in these settings and not rely on shell features, such as tilde (`~/`) or parameter (`${HOME}`) expansion.
 
 ## Unsupported R installations

--- a/run-interactive-apps.qmd
+++ b/run-interactive-apps.qmd
@@ -4,7 +4,7 @@ title: "Run Interactive Apps"
 
 Positron provides a simplified method for running interactive apps via the **Play** button. Instead of running an app from a **Terminal**, you can run supported apps by clicking the **Play** button in Editor Actions. Additionally, you can start a supported app in debug mode through the **Play** button context menu.
 
-![Positron Run App button in Editor Actions](images/run-app-button.png)
+![Positron App Launcher button in Editor Actions](images/run-app-button.png)
 
 ## Supported app frameworks
 
@@ -22,7 +22,7 @@ Currently, Positron supports the following Python app frameworks:
 1. Open the `.py` file of a supported app framework.
 2. In Editor Actions, click **Play**.
 
-    ![Positron Run App Play button](images/run-app-play-button.png)
+    ![Positron App Launcher Play button](images/run-app-play-button.png)
 
 Then, Positron runs the app in a dedicated **Terminal** tab and opens the app URL in the **Viewer** pane.
 

--- a/troubleshooting.qmd
+++ b/troubleshooting.qmd
@@ -14,20 +14,20 @@ A window reload shouldn't cause you to lose any state, but it does cause the Pos
 
 ### Output panel
 
-Python and R logs are emitted in the Output panel. Each runtime starts several output channels that can be used to help diagnose problems with a respective part of the system. 
+Python and R logs are emitted in the Output panel. Each interpreter starts several output channels that can be used to help diagnose problems with a respective part of the system. 
 
-Run the _Output: Show Output Channels_ command to show a list of output channels. You can then select one to view its output by name, like "Positron R Extension". Here's a list of some Positron-specific channels you may be interested in:
+Run the _Output: Show Output Channels_ command to show a list of output channels. You can then select one to view its output by name, like "R Language Pack". Here's a list of some Positron-specific channels you may be interested in:
 
 | Channel | Description |
 | ------- | ----------- |
-| Console: Python X.Y.Z | Communication with the Python kernel: requests to execute code, output shown in the Console, data used to build plots/environment/help panes, etc. |
-| Console: R X.Y.Z | Communication with the R kernel (similar to Python) |
-| Python Language Server | Debug logs from the server side of Positron's Python language server |
-| Positron R Language Server | Debug logs from the server side of Positron's R language server |
+| Kernel | Communication from the Python or R kernel itself: requests to execute code, output to be shown in the Console, data used to build plots/environment/help panes, etc. This channel will have a name like "R X.Y.Z: Kernel." |
+| Console/Notebook | Communication from the Console or Notebook running the Python or R kernel: messages the Console sends and receives, changes in the Console's state, etc. This channel will have a name like "Python X.Y.Z: Console." |
+| Language Server | Debug logs from the server side of the language server Positron uses for any given interpreter. This channel will have a name like "R X.Y.Z: Language Server (Console)." |
+| Language Pack | Debug logs from the extension that Positron uses to discover, start, and manage interpreters. This channel will have a name like "Python Language Pack." |
 
 ### Log level
 
-Most of these output channels have a log level associated with them that you can change in the settings UI. 
+Most of these output channels have a log level associated with them that you can change in the settings UI. For example, you can change the log level for how much information is passed from the R kernel itself to the "R X.Y.Z: Kernel" output channel using the `positron.r.kernel.logLevel` setting.
 
 ## Developer tools
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5824 mostly, except for the remote SSH screenshots.