### PR TITLE
Add privacy section to explain data collection in Positron

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,7 +25,7 @@ website:
     right:
       - text: "License"
         href: licensing.qmd
-      - text: "Privacy"
+      - text: "Privacy Policy"
         aria-label: "Link to Privacy Policy"
         href: "https://posit.co/about/privacy-policy/"
       - icon: question-circle-fill
@@ -84,3 +84,4 @@ website:
         - troubleshooting.qmd
         - feedback.qmd
         - faqs.qmd
+        - privacy.qmd

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -8,7 +8,7 @@ Posit Software, PBC is committed to protecting your privacy. Our [Privacy Policy
 
 ### Why do we collect data?
 
-Positron uses this information anonymously and in aggregate to determine how often our products are used and which data science features are important to our users. This helps us prioritize feature improvements or novel features in future versions of our product.
+Posit uses this information anonymously and in aggregate to determine how often our products are used and which data science features are important to our users. This helps us prioritize feature improvements or novel features in future versions of our product.
 
 ### What information do we collect?
 

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -1,0 +1,26 @@
+---
+title: "Privacy"
+---
+
+## Positron Data Collection
+
+Posit Software, PBC is committed to protecting your privacy. Our [Privacy Policy](https://posit.co/about/privacy-policy/) applies to the information that we obtain through your use of our products and/or services and our websites, including [https://positron.posit.co](https://positron.posit.co).
+
+### Why do we collect data?
+
+Positron uses this information anonymously and in aggregate to determine how often our products are used and which data science features are important to our users. This helps us prioritize feature improvements or novel features in future versions of our product.
+
+### What information do we collect?
+
+#### Website and download data
+
+When you visit our website or download our software, Posit logs network access information. Positron also includes in-product features that periodically check for new versions of the product or its extensions. These access logs include common information about the client, including the operating system, browser type, IP address, referral sources, timestamp and URI accessed. 
+
+- To stop Positron checking for product updates, disable the setting `update.autoUpdate`. 
+- To stop Positron checking for extension updates, disable the setting `extensions.autoCheckUpdates`.
+
+#### Primary Language reporting
+
+Positron also includes an option to share the primary data science languages in use, such as Python or R.
+
+- To stop Positron sharing the primary data science languages in use, disable the setting `update.primaryLanguageReporting`.

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -4,7 +4,7 @@ title: "Privacy"
 
 ## Positron data collection
 
-Posit Software, PBC is committed to protecting your privacy. Our [Privacy Policy](https://posit.co/about/privacy-policy/) applies to the information that we obtain through your use of our products and/or services and our websites, including [https://positron.posit.co](https://positron.posit.co).
+Posit Software, PBC is committed to protecting your privacy. Our [Privacy Policy](https://posit.co/about/privacy-policy/) applies to the information that we obtain through your use of our products and/or services and our websites, including <https://positron.posit.co>.
 
 ### Why do we collect data?
 

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -14,7 +14,7 @@ Positron uses this information anonymously and in aggregate to determine how oft
 
 #### Website and download data
 
-When you visit our website or download our software, Posit logs network access information. Positron also includes in-product features that periodically check for new versions of the product or its extensions. These access logs include common information about the client, including the operating system, browser type, IP address, referral sources, timestamp and URI accessed. 
+When you visit our website or download our software, Posit logs network access information. Positron also includes in-product features that periodically check for new versions of the product or its extensions. These access logs include common information about the client, including the operating system, browser type, IP address, referral sources, timestamp, and URI accessed. 
 
 - To stop Positron checking for product updates, disable the setting `update.autoUpdate`. 
 - To stop Positron checking for extension updates, disable the setting `extensions.autoCheckUpdates`.

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -21,6 +21,6 @@ When you visit our website or download our software, Posit logs network access i
 
 #### Primary language reporting
 
-Positron also includes an option to share the primary data science languages in use, such as Python or R.
+Positron also includes an option to share the primary data science languages in use, such as Python and/or R.
 
 - To stop Positron sharing the primary data science languages in use, disable the setting `update.primaryLanguageReporting`.

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -16,7 +16,7 @@ Posit uses this information anonymously and in aggregate to determine how often 
 
 When you visit our website or download our software, Posit logs network access information. Positron also includes in-product features that periodically check for new versions of the product or its extensions. These access logs include common information about the client, including the operating system, browser type, IP address, referral sources, timestamp, and URI accessed. 
 
-- To stop Positron checking for product updates, disable the setting `update.autoUpdate`. 
+- To stop Positron checking for product updates, choose `none` for the setting `update.mode`.
 - To stop Positron checking for extension updates, disable the setting `extensions.autoCheckUpdates`.
 
 #### Primary language reporting

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -2,7 +2,7 @@
 title: "Privacy"
 ---
 
-## Positron Data Collection
+## Positron data collection
 
 Posit Software, PBC is committed to protecting your privacy. Our [Privacy Policy](https://posit.co/about/privacy-policy/) applies to the information that we obtain through your use of our products and/or services and our websites, including [https://positron.posit.co](https://positron.posit.co).
 
@@ -19,7 +19,7 @@ When you visit our website or download our software, Posit logs network access i
 - To stop Positron checking for product updates, disable the setting `update.autoUpdate`. 
 - To stop Positron checking for extension updates, disable the setting `extensions.autoCheckUpdates`.
 
-#### Primary Language reporting
+#### Primary language reporting
 
 Positron also includes an option to share the primary data science languages in use, such as Python or R.
 


### PR DESCRIPTION
Adds more information about what data is collected and why.

Also correct footer to refer to Posit's "Privacy Policy" consistently as our main site.

Addresses https://github.com/posit-dev/positron-builds/issues/226