### PR TITLE
remove note that tilde-prefixed paths are not supported

### DIFF
--- a/r-installations.qmd
+++ b/r-installations.qmd
@@ -49,7 +49,7 @@ If you have an R installation that won't be discovered by the search strategy de
 
 One way to navigate to these settings is to use the command palette to open Preferences: Open Settings.
 Then navigate to **Extensions** > **R** > **Advanced**.
-It's important to use absolute paths in these settings and not rely on shell features, such as tilde (`~/`) or parameter (`${HOME}`) expansion.
+It's important to use absolute paths in these settings and not rely on shell features, such as parameter expansion (e.g., `${HOME}`).
 
 ## Unsupported R installations
 


### PR DESCRIPTION
Once https://github.com/posit-dev/positron/pull/6621 is merged, tilde-prefixed paths will be supported in the `positron.r.customRootFolders`, `positron.r.customBinaries` and other r interpreter settings, so we can remove this note.

Preview: https://deploy-preview-55--positron-posit-co.netlify.app/r-installations.html#customizing-r-discovery