### PR TITLE
Move RStudio keybindings to a section to assist migration

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -78,6 +78,7 @@ website:
         - extension-development.qmd
         - section: "Migrating from RStudio"
           contents:
+          - rstudio-keybindings.qmd
           - rstudio-rproj-file.qmd
           - r-snippets.qmd
 

--- a/keyboard-shortcuts.qmd
+++ b/keyboard-shortcuts.qmd
@@ -29,37 +29,10 @@ Positron's keyboard shortcuts, with a few exceptions, are a superset of the keyb
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> | Check the current R package, if any | 
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> | Document the current R package, if any | 
 
-## RStudio keymap
+## RStudio keybindings
 
-If you'd prefer to use RStudio keybindings, do the following:
-
-- Open Positron's settings via <kbd>Cmd/Ctrl</kbd>+<kbd>,</kbd>
-- Search for "keymap", or navigate to *Extensions > RStudio Keymap*
-- Check the "Enable RStudio key mappings for Positron" checkbox
-
-The following RStudio keymappings will then be enabled:
-
-| Shortcut | Description |
-| -------- | ----------- |
-| <kbd>Ctrl</kbd>+<kbd>1</kbd>  |  Focus Source | 
-| <kbd>Ctrl</kbd>+<kbd>2</kbd>  |  Focus Console | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>.</kbd>  |  Go to Symbol | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> |  Comment/Uncomment a line | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> |  Create a new R file | 
-| <kbd>F2</kbd>  |  Go to definition | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>I</kbd> |  Reindent selection | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd> |  Reformat selection | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> |  Source the current R script | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> |  Rename | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd> |  Insert a new Quarto/R Markdown cell | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd> |  Open version control pane | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Left</kbd> |  Go to previous tab | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Right</kbd> |  Go to next tab | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>D</kbd> |  Delete the current line | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> |  Insert pipe operator | 
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |  Insert section | 
-| <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> | Open global keybindings list |
-| <kbd>Alt</kbd>+<kbd>-</kbd> | Insert left assignment operator `<-` |
+If you'd prefer to use RStudio keybindings, see [this section](rstudio-keybindings.qmd) for
+instructions on how to enable them for Positron.
 
 ## Custom shortcuts
 

--- a/keyboard-shortcuts.qmd
+++ b/keyboard-shortcuts.qmd
@@ -31,8 +31,7 @@ Positron's keyboard shortcuts, with a few exceptions, are a superset of the keyb
 
 ## RStudio keybindings
 
-If you'd prefer to use RStudio keybindings, see [this section](rstudio-keybindings.qmd) for
-instructions on how to enable them for Positron.
+If you'd prefer to use RStudio keybindings, see [our instructions](rstudio-keybindings.qmd) on how to enable them for Positron.
 
 ## Custom shortcuts
 

--- a/rstudio-keybindings.qmd
+++ b/rstudio-keybindings.qmd
@@ -1,5 +1,5 @@
 ---
-title: "RStudio keybindings"
+title: "RStudio Keybindings"
 ---
 
 <!-- vale Posit.Contractions = NO -->

--- a/rstudio-keybindings.qmd
+++ b/rstudio-keybindings.qmd
@@ -1,0 +1,38 @@
+---
+title: "RStudio keybindings"
+---
+
+<!-- vale Posit.Contractions = NO -->
+
+## RStudio keybindings in Positron
+
+If you'd prefer to use RStudio keybindings in Positron, do the following:
+
+- Open Positron's settings via <kbd>Cmd/Ctrl</kbd>+<kbd>,</kbd>
+- Search for "RStudio", or navigate to *Workbench > Keybindings > RStudio Keybindings*
+- Check the "Enable RStudio keybindings" checkbox
+- Restart Positron
+
+The following RStudio keybindings will then be enabled:
+
+| Shortcut | Description |
+| -------- | ----------- |
+| <kbd>Ctrl</kbd>+<kbd>1</kbd>  |  Focus Source |
+| <kbd>Ctrl</kbd>+<kbd>2</kbd>  |  Focus Console |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>.</kbd>  |  Go to Symbol |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> |  Comment/Uncomment a line |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> |  Create a new R file |
+| <kbd>F2</kbd>  |  Go to definition |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>I</kbd> |  Reindent selection |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd> |  Reformat selection |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> |  Source the current R script |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> |  Rename |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd> |  Insert a new Quarto/R Markdown cell |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd> |  Open version control pane |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Left</kbd> |  Go to previous tab |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Right</kbd> |  Go to next tab |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>D</kbd> |  Delete the current line |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> |  Insert pipe operator |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |  Insert section |
+| <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> | Open global keybindings list |
+| <kbd>Alt</kbd>+<kbd>-</kbd> | Insert left assignment operator `<-` |


### PR DESCRIPTION
Several uses did not know that RStudio keybindings were available in Positron.

Also, since these were recently moved from a keymap extension to core keybinding settings in https://github.com/posit-dev/positron/pull/7362, fixing the documentation to reflect their new location.