### PR TITLE
Folders Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ Vale runs [via GH action on PRs](https://github.com/posit-dev/positron-website/a
 
 ## Local development
 
-If you have Quarto and Chrome or Edge installed locally, you can preview the site by running one of the Debug Configurations in VS Code or Positron.
+If you have [Quarto installed locally](https://quarto.org/docs/get-started/) and Chrome or Edge, you can preview the site by running one of the Debug Configurations in VS Code or Positron.
 
 The configurations run `quarto preview` and then open the site in a new browser window.
 - **Preview Docs (Chrome)**: Preview the site in Chrome
 - **Preview Docs (Edge)**: Preview the site in Edge
 
 The site will re-render as you make changes to the `.qmd` files.
+
+Alternatively, you can run the command `quarto preview` in the terminal.
 
 ## Managing execution and rendering
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -74,6 +74,7 @@ website:
         - remote-ssh.qmd
         - updating.qmd
         - extension-development.qmd
+        - folder-templates.qmd
         - section: "Migrating from RStudio"
           contents:
           - rstudio-keybindings.qmd

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -53,4 +53,6 @@ To learn more about `renv`, see the [Introduction to renv guide](https://rstudio
 
 ### Finish
 
-Once you are satisfied with your configuration options, select **Create** to create your new folder with the applied settings. Positron creates the folder and applies your selected template and settings. Once setup is complete, you will be prompted open the folder in the current window or a new window to begin working.
+After you review your configuration options, select **Create** to set up your new folder with the selected template and settings. When setup is complete, choose whether to open the folder in the current window or a new window.
+
+By default, Positron starts a session for the interpreter you selected in the template. You can customize this behavior in the settings. For more details, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -4,7 +4,9 @@ title: "Folder Templates"
 
 The "New Folder from Template" feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
 
-To create a new folder from one of the available templates in Positron, select the "New" dropdown menu in the top-left or the workspace switcher in the top-right. Select the "New Folder from Template" option to bring up the dialog.
+You can bring up the **New Folder from Template** dialog by selecting the "New" dropdown menu in the top-left or selecting the workspace switcher in the top-right. Select the "New Folder from Template" option from the menu to bring up the dialog.
+
+You can also bring up the dialog by running the _Workspaces: New Folder from Template..._ command in the Command Palette.
 
 ### Select a template
 

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -8,7 +8,7 @@ After you finish setup, Positron creates your new folder with the selected templ
 
 By default, Positron starts a session for the interpreter you selected in the template. You can customize this behavior in the settings. For more details, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).
 
-## Why use folder templates?
+## Why use folder templates
 
 Folder templates allow you to start new projects quickly. They provide a consistent structure, recommended files, and environment configuration for your language or framework. This is especially helpful if you are:
 

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -25,6 +25,12 @@ When you use the **New Folder from Template** feature, Positron creates a new fo
 
 After setup, your project is ready for development. You can start working right away, knowing your environment and files are organized for success.
 
+## Using a template
+
+To bring up the **New Folder from Template** dialog, select the "New" dropdown menu in the top-left or select the workspace switcher in the top-right. Select the "New Folder from Template" option from the menu to bring up the dialog.
+
+You can also bring up the dialog by running the _Workspaces: New Folder from Template..._ command in the Command Palette.
+
 ## About Python templates
 
 Python templates help you create projects in an isolated environment. This prevents conflicts between package versions and makes your work more reproducible. When you use a Python template, Positron can:

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -2,7 +2,7 @@
 title: "Folder Templates"
 ---
 
-## New Folder from Template
+## New folder from template
 
 The "New Folder from Template" feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
 

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -2,8 +2,6 @@
 title: "Folder Templates"
 ---
 
-## New folder from template
-
 The "New Folder from Template" feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
 
 To create a new folder from one of the available templates in Positron, select the "New" dropdown menu in the top-left or the workspace switcher in the top-right. Select the "New Folder from Template" option to bring up the dialog.
@@ -21,13 +19,16 @@ After you select a template, enter a name for your new folder and choose a locat
 When you select a Python template, the dialog guides you through setting up your Python environment. This ensures your project starts with the right tools and interpreter for your work.
 
 **How would you like to set up your Python environment?:**
+
 - **Create a new virtual environment:** Recommended for most users. This option creates an isolated environment for your project, which helps avoid conflicts with other Python projects on your system.
 - **Use an existing environment:** Choose this if you already have a Python environment you want to use.
 
 **Environment Creation:**
+
 Select a tool such as `venv`, `conda`, or `uv` to create your new environment. See the [Supported environment managers guide](python-installations.qmd#supported-environment-managers) to learn about which managers are supported.
 
 **Python Interpreter:**
+
 - Choose the version of Python you want to use. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and details about how Positron discovers and manages Python environments.
 
 
@@ -36,11 +37,13 @@ Select a tool such as `venv`, `conda`, or `uv` to create your new environment. S
 When you select an R template, the dialog helps you configure your R environment for the new project.
 
 **R Version:**
+
 - Select the version of R you want to use. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and details about how Positron discovers R versions.
 
 
 **Advanced configuration:**
-- You can check the **Use `renv` to create a reproducible environment** box to initialize your folder with `renv`.
+
+- You can check the **Use \`renv\` to create a reproducible environment** box to initialize your folder with `renv`.
 
 `renv` is an R package that helps you manage project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project with other people or computers. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, making it reliable and reproducible. This is especially helpful when collaborating with others or working on long-term projects.
 

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -2,9 +2,9 @@
 title: "Folder Templates"
 ---
 
-The "New Folder from Template" feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
+The New Folder from Template feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
 
-You can bring up the **New Folder from Template** dialog by selecting the "New" dropdown menu in the top-left or selecting the workspace switcher in the top-right. Select the "New Folder from Template" option from the menu to bring up the dialog.
+To bring up the **New Folder from Template** dialog, select the "New" dropdown menu in the top-left or select the workspace switcher in the top-right. Select the "New Folder from Template" option from the menu to bring up the dialog.
 
 You can also bring up the dialog by running the _Workspaces: New Folder from Template..._ command in the Command Palette.
 
@@ -14,45 +14,44 @@ When you open the **New Folder from Template** dialog, you will see a list of av
 
 Choose a template that best matches the language or framework for the work you are doing. The "Empty Project" option allows you to create a blank folder with no additional files or configuration.
 
-After you select a template, enter a name for your new folder and choose a location on your system. You can check the **Initialize Git repository** box if you want to create a Git repository in the new folder. Select **Next** to continue to template-specific configuration options.
+### Folder name and location
+
+After you select a template, enter a name for your new folder and choose a location on your system. Check the **Initialize Git repository** box if you want to create a Git repository in the new folder. Select **Next** to continue to template-specific configuration options.
+
 
 ### Python templates
 
-When you select a Python template, the dialog guides you through setting up your Python environment. This ensures your project starts with the right tools and interpreter for your work.
+When you select a Python-based template, the dialog guides you through setting up your Python environment. This ensures your project starts with the right tools and interpreter for your work.
 
-**How would you like to set up your Python environment?:**
+A virtual environment keeps your project’s Python packages separate from other projects. This helps prevent conflicts between package versions and makes your work more reproducible. 
 
-- **Create a new virtual environment:** Recommended for most users. This option creates an isolated environment for your project, which helps avoid conflicts with other Python projects on your system.
-- **Use an existing environment:** Choose this if you already have a Python environment you want to use.
+Select **Create a new virtual environment** if you want a clean, isolated setup for your project. This is the best choice for most users and new projects. Select **Use an existing environment** if you already have a Python environment with the packages you need, or if you require a shared environment. This option is helpful when you want to use specific tools or settings that are already configured.
 
-**Environment Creation:**
+**Environment Creation**
 
-Select a tool such as `venv`, `conda`, or `uv` to create your new environment. See the [Supported environment managers guide](python-installations.qmd#supported-environment-managers) to learn about which managers are supported.
+If you chose to create a new environment, you will need to select an environment manager tool such as `venv`, `conda`, or `uv` to create your new environment. For details about supported managers, see the [supported environment managers guide](python-installations.qmd#supported-environment-managers).
 
-**Python Interpreter:**
+**Python Interpreter**
 
-- Choose the version of Python you want to use. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and details about how Positron discovers and manages Python environments.
+Select the version of Python you want to use. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and for details about how Positron discovers and manages Python environments.
 
 
 ### R templates
 
-When you select an R template, the dialog helps you configure your R environment for the new project.
+When you select an R-based template, the dialog guides you through setting up your R environment. This ensures your project starts with the right tools and interpreter for your work.
 
-**R Version:**
+**R version**
 
-- Select the version of R you want to use. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and details about how Positron discovers R versions.
+Select the version of R you want to use. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and for details about how Positron discovers R versions.
 
+**Advanced configuration**
 
-**Advanced configuration:**
+You can choose to use `renv` for reproducible environments. Select **Use `renv` to create a reproducible environment** if you want to manage your project dependencies and ensure consistent package versions.
 
-- You can check the **Use \`renv\` to create a reproducible environment** box to initialize your folder with `renv`.
-
-`renv` is an R package that helps you manage project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project with other people or computers. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, making it reliable and reproducible. This is especially helpful when collaborating with others or working on long-term projects.
-
-To learn more about `renv`, see the [Introduction to renv guide](https://rstudio.github.io/renv/articles/renv.html).
+`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, which makes your work more reliable and reproducible. This is especially helpful when you collaborate with others or work on long-term projects. To learn more about `renv`, see the [Introduction to renv guide](https://rstudio.github.io/renv/articles/renv.html).
 
 ### Finish
 
-After you review your configuration options, select **Create** to set up your new folder with the selected template and settings. When setup is complete, choose whether to open the folder in the current window or a new window.
+After you review your configuration options, select **Create** to set up your new folder with the selected template and settings. When setup is complete, select whether to open the folder in the current window or a new window.
 
-By default, Positron starts a session for the interpreter you selected in the template. You can customize this behavior in the settings. For more details, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).
+By default, Positron starts a session for the interpreter you selected in the template. For more details on how to customize this behavior, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -9,11 +9,12 @@ The "New Folder from Template" feature helps you quickly setup a a folder with a
 To create a new folder from one of the available templates in Positron, select the "New" dropdown menu in the top-left or the workspace switcher in the top-right. Select the "New Folder from Template" option to bring up the dialog.
 
 ### Select a template
-To create an empty folder, you can select the "Empty Project" option, otherwise select an option that best matches the work you are doing and select "Next".
 
-You will be prompted to select a name for the folder and a location for the folder on your system. You can check the "Initialize Git repository" box if you want to initialize a git repository in the folder, then select "Next".
+When you open the **New Folder from Template** dialog, you will see a list of available templates.
 
-This next section will contain configuration options for the template.
+Choose a template that best matches the language or framework for the work you are doing. The "Empty Project" option allows you to create a blank folder with no additional files or configuration.
+
+After you select a template, enter a name for your new folder and choose a location on your system. You can check the **Initialize Git repository** box if you want to create a Git repository in the new folder. Select **Next** to continue to template-specific configuration options.
 
 ### Python templates
 

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -39,4 +39,4 @@ R templates help you create projects with the right R version.
 
 You can choose to use `renv` for reproducibility, but this is an advanced option. Most users should leave this box unchecked unless you are familiar with `renv` and need strict dependency management for your project.
 
-`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This is helpful for power users who need to share projects or ensure exact package versions. You can learn more about renv [here](https://rstudio.github.io/renv/articles/renv.html).
+`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This is helpful for power users who need to share projects or ensure exact package versions. [Learn more about renv.](https://rstudio.github.io/renv/articles/renv.html)

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -6,7 +6,7 @@ title: "Folder Templates"
 
 The "New Folder from Template" feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
 
-To create a new folder from one of the available templates in Positron, select the "New" dropdown menu in the top left. Select the "New Folder from Template" option to bring up the dialog.
+To create a new folder from one of the available templates in Positron, select the "New" dropdown menu in the top-left or the workspace switcher in the top-right. Select the "New Folder from Template" option to bring up the dialog.
 
 ### Select a template
 To create an empty folder, you can select the "Empty Project" option, otherwise select an option that best matches the work you are doing and select "Next".
@@ -48,4 +48,3 @@ To learn more about `renv`, see the [Introduction to renv guide](https://rstudio
 ### Finish
 
 Once you are satisfied with your configuration options, select **Create** to create your new folder with the applied settings. Positron creates the folder and applies your selected template and settings. Once setup is complete, you will be prompted open the folder in the current window or a new window to begin working.
-

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -2,56 +2,44 @@
 title: "Folder Templates"
 ---
 
-The New Folder from Template feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
+The **New Folder from Template** feature helps you start new projects quickly and consistently. Use this feature when you want to avoid manual setup, follow best practices, or ensure your project includes all recommended files and settings from the start.
 
-To bring up the **New Folder from Template** dialog, select the "New" dropdown menu in the top-left or select the workspace switcher in the top-right. Select the "New Folder from Template" option from the menu to bring up the dialog.
+After you finish setup, Positron creates your new folder with the selected template and settings. You can open the folder in the current window or a new window.
 
-You can also bring up the dialog by running the _Workspaces: New Folder from Template..._ command in the Command Palette.
+By default, Positron starts a session for the interpreter you selected in the template. You can customize this behavior in the settings. For more details, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).
 
-### Select a template
+## Why use folder templates?
 
-When you open the **New Folder from Template** dialog, you will see a list of available templates.
+Folder templates allow you to start new projects quickly. They provide a consistent structure, recommended files, and environment configuration for your language or framework. This is especially helpful if you are:
 
-Choose a template that best matches the language or framework for the work you are doing. The "Empty Project" option allows you to create a blank folder with no additional files or configuration.
+- Working in a team and need a shared, predictable setup
+- Looking to ensure reproducibility and easier collaboration
 
-### Folder name and location
+## What to expect when you use a template
 
-After you select a template, enter a name for your new folder and choose a location on your system. Check the **Initialize Git repository** box if you want to create a Git repository in the new folder. Select **Next** to continue to template-specific configuration options.
+When you use the **New Folder from Template** feature, Positron creates a new folder based on your chosen template. The folder includes:
 
+- The recommended folder structure for your language or framework
+- Environment setup for Python or R, if applicable
+- Optional version control setup (if you choose to initialize a Git repository)
 
-### Python templates
+After setup, your project is ready for development. You can start working right away, knowing your environment and files are organized for success.
 
-When you select a Python-based template, the dialog guides you through setting up your Python environment. This ensures your project starts with the right tools and interpreter for your work.
+## About Python templates
 
-A virtual environment keeps your project’s Python packages separate from other projects. This helps prevent conflicts between package versions and makes your work more reproducible. 
+Python templates help you create projects in an isolated environment. This prevents conflicts between package versions and makes your work more reproducible. When you use a Python template, Positron can:
 
-Select **Create a new virtual environment** if you want a clean, isolated setup for your project. This is the best choice for most users and new projects. Select **Use an existing environment** if you already have a Python environment with the packages you need, or if you require a shared environment. This option is helpful when you want to use specific tools or settings that are already configured.
+- Set up a new virtual environment for your project, or let you use an existing one
+- Help you choose an environment manager, such as `venv`, `conda`, or `uv`. For details about supported managers, see the [supported environment managers guide](python-installations.qmd#supported-environment-managers)
+- Let you select the Python version for your project. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and for details about how Positron discovers and manages Python environments.
 
-**Environment Creation**
+This setup is ideal for most users, especially if you want to avoid issues with package versions or need to share your project with others.
 
-If you chose to create a new environment, you will need to select an environment manager tool such as `venv`, `conda`, or `uv` to create your new environment. For details about supported managers, see the [supported environment managers guide](python-installations.qmd#supported-environment-managers).
+## About R templates
 
-**Python Interpreter**
+R templates help you create projects with the right R version and, optionally, a reproducible environment using `renv`. When you use an R template, Positron can:
 
-Select the version of Python you want to use. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and for details about how Positron discovers and manages Python environments.
+- Set up your project to use a specific version of R. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and for details about how Positron discovers R versions.
+- Offer the option to use `renv` for reproducibility
 
-
-### R templates
-
-When you select an R-based template, the dialog guides you through setting up your R environment. This ensures your project starts with the right tools and interpreter for your work.
-
-**R version**
-
-Select the version of R you want to use. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and for details about how Positron discovers R versions.
-
-**Advanced configuration**
-
-You can choose to use `renv` for reproducible environments. Select **Use `renv` to create a reproducible environment** if you want to manage your project dependencies and ensure consistent package versions.
-
-`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, which makes your work more reliable and reproducible. This is especially helpful when you collaborate with others or work on long-term projects. To learn more about `renv`, see the [Introduction to renv guide](https://rstudio.github.io/renv/articles/renv.html).
-
-### Finish
-
-After you review your configuration options, select **Create** to set up your new folder with the selected template and settings. When setup is complete, select whether to open the folder in the current window or a new window.
-
-By default, Positron starts a session for the interpreter you selected in the template. For more details on how to customize this behavior, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).
+`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project or move it to another computer. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, which makes your work more reliable and reproducible. This is especially helpful when you collaborate with others or work on long-term projects. [Learn more about renv](https://rstudio.github.io/renv/articles/renv.html).

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -1,0 +1,51 @@
+---
+title: "Folder Templates"
+---
+
+## New Folder from Template
+
+The "New Folder from Template" feature helps you quickly setup a a folder with an environment using a predefined template for a language or framework. 
+
+To create a new folder from one of the available templates in Positron, select the "New" dropdown menu in the top left. Select the "New Folder from Template" option to bring up the dialog.
+
+### Select a template
+To create an empty folder, you can select the "Empty Project" option, otherwise select an option that best matches the work you are doing and select "Next".
+
+You will be prompted to select a name for the folder and a location for the folder on your system. You can check the "Initialize Git repository" box if you want to initialize a git repository in the folder, then select "Next".
+
+This next section will contain configuration options for the template.
+
+### Python templates
+
+When you select a Python template, the dialog guides you through setting up your Python environment. This ensures your project starts with the right tools and interpreter for your work.
+
+**How would you like to set up your Python environment?:**
+- **Create a new virtual environment:** Recommended for most users. This option creates an isolated environment for your project, which helps avoid conflicts with other Python projects on your system.
+- **Use an existing environment:** Choose this if you already have a Python environment you want to use.
+
+**Environment Creation:**
+Select a tool such as `venv`, `conda`, or `uv` to create your new environment. See the [Supported environment managers guide](python-installations.qmd#supported-environment-managers) to learn about which managers are supported.
+
+**Python Interpreter:**
+- Choose the version of Python you want to use. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and details about how Positron discovers and manages Python environments.
+
+
+### R templates
+
+When you select an R template, the dialog helps you configure your R environment for the new project.
+
+**R Version:**
+- Select the version of R you want to use. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and details about how Positron discovers R versions.
+
+
+**Advanced configuration:**
+- You can check the **Use `renv` to create a reproducible environment** box to initialize your folder with `renv`.
+
+`renv` is an R package that helps you manage project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project with other people or computers. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, making it reliable and reproducible. This is especially helpful when collaborating with others or working on long-term projects.
+
+To learn more about `renv`, see the [Introduction to renv guide](https://rstudio.github.io/renv/articles/renv.html).
+
+### Finish
+
+Once you are satisfied with your configuration options, select **Create** to create your new folder with the applied settings. Positron creates the folder and applies your selected template and settings. Once setup is complete, you will be prompted open the folder in the current window or a new window to begin working.
+

--- a/folder-templates.qmd
+++ b/folder-templates.qmd
@@ -2,28 +2,20 @@
 title: "Folder Templates"
 ---
 
-The **New Folder from Template** feature helps you start new projects quickly and consistently. Use this feature when you want to avoid manual setup, follow best practices, or ensure your project includes all recommended files and settings from the start.
+The **New Folder from Template** feature helps you start new projects faster. Use this feature when you want to avoid manual setup, or ensure your project includes all recommended files and settings from the start. Instead of running multiple setup commands, you can make a few selections and Positron sets up everything for you automatically. This feature is ideal if you want to:
 
-After you finish setup, Positron creates your new folder with the selected template and settings. You can open the folder in the current window or a new window.
+- Save time and avoid manual setup steps
+- Start with a ready-to-use environment for your language or framework
 
-By default, Positron starts a session for the interpreter you selected in the template. You can customize this behavior in the settings. For more details, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).
+## Template contents
 
-## Why use folder templates
+When you use a folder template, Positron creates a new project folder and configures the following items:
 
-Folder templates allow you to start new projects quickly. They provide a consistent structure, recommended files, and environment configuration for your language or framework. This is especially helpful if you are:
-
-- Working in a team and need a shared, predictable setup
-- Looking to ensure reproducibility and easier collaboration
-
-## What to expect when you use a template
-
-When you use the **New Folder from Template** feature, Positron creates a new folder based on your chosen template. The folder includes:
-
-- The recommended folder structure for your language or framework
-- Environment setup for Python or R, if applicable
-- Optional version control setup (if you choose to initialize a Git repository)
-
-After setup, your project is ready for development. You can start working right away, knowing your environment and files are organized for success.
+- **Environment directory:** A dedicated environment (such as `.venv` for Python) so you can install packages without affecting other projects.
+- **Version control:** A `.git` directory and a `.gitignore` file with common patterns for your language or framework.
+- **Directory structure:** Folders and files recommended for your template type, so your project is organized from the start.
+- **Interpreter instance:** A new interpreter session starts automatically, ready for you to run code.
+- **Editor:** An untitled file is opened in the editor, or a notebook is started with your chosen interpreter.
 
 ## Using a template
 
@@ -31,21 +23,20 @@ To bring up the **New Folder from Template** dialog, select the "New" dropdown m
 
 You can also bring up the dialog by running the _Workspaces: New Folder from Template..._ command in the Command Palette.
 
+After setup, your project is ready for development. You can open the folder in the current window or a new window. By default, Positron starts a session for the interpreter you selected. You can customize this behavior in the settings. For more details, see the [interpreter startup guide](interpreter-startup.qmd#configuring-interpreter-startup).
+
 ## About Python templates
 
-Python templates help you create projects in an isolated environment. This prevents conflicts between package versions and makes your work more reproducible. When you use a Python template, Positron can:
+Python templates create a project with an isolated environment. This prevents conflicts between package versions and makes your work more reproducible. 
 
-- Set up a new virtual environment for your project, or let you use an existing one
-- Help you choose an environment manager, such as `venv`, `conda`, or `uv`. For details about supported managers, see the [supported environment managers guide](python-installations.qmd#supported-environment-managers)
-- Let you select the Python version for your project. If you do not see the version you need, see the [Discovering Python Installations guide](python-installations.qmd) for help adding new interpreters and for details about how Positron discovers and manages Python environments.
+You can choose to use a `pyproject.toml` file for advanced dependency management.
 
-This setup is ideal for most users, especially if you want to avoid issues with package versions or need to share your project with others.
+For more about environment managers, see the [supported environment managers guide](python-installations.qmd#supported-environment-managers). For details about Python interpreter discovery, see the [Discovering Python Installations guide](python-installations.qmd).
 
 ## About R templates
 
-R templates help you create projects with the right R version and, optionally, a reproducible environment using `renv`. When you use an R template, Positron can:
+R templates help you create projects with the right R version. 
 
-- Set up your project to use a specific version of R. If the version you need is not listed, see the [Discovering R Installations guide](r-installations.qmd) for help adding new R versions and for details about how Positron discovers R versions.
-- Offer the option to use `renv` for reproducibility
+You can choose to use `renv` for reproducibility, but this is an advanced option. Most users should leave this box unchecked unless you are familiar with `renv` and need strict dependency management for your project.
 
-`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This makes it easy to share your project or move it to another computer. Using `renv` helps you avoid problems caused by package updates or differences between computers. It ensures your project always uses the correct package versions, which makes your work more reliable and reproducible. This is especially helpful when you collaborate with others or work on long-term projects. [Learn more about renv](https://rstudio.github.io/renv/articles/renv.html).
+`renv` is an R package that manages project dependencies. It creates a snapshot of the R packages in your project and saves them in a `renv.lock` file. This is helpful for power users who need to share projects or ensure exact package versions. You can learn more about renv [here](https://rstudio.github.io/renv/articles/renv.html).

--- a/python-installations.qmd
+++ b/python-installations.qmd
@@ -57,7 +57,7 @@ You can create new Python environments directly from Positron using the _Python:
 
 The environment will be created in your workspace and automatically discovered.
 
-You can also use the **New Folder From Template** feature to create a new Python project, and set up an environment as part of the project.
+You can also use the [New Folder From Template feature](folder-templates.qmd#new-folder-from-template) to create a new Python project, and set up an environment as part of the project.
 
 ### Discovering existing environments
 


### PR DESCRIPTION
Addresses posit-dev/positron#7563.
 
 This doc covers how to use the "New Folder from template" dialog. We quickly cover why a user would want to use this feature, how to get to the dialog, and what the different configuration options are. The section tries to generically talk about Python and R templates (notebooks are covered by the python template section).
 
I have decided to forego screenshots in this document. I think we can link to the ui interface doc if folks need to see a screenshot of the menus that lead to the dialog (new menu and workspace switcher). I think we can avoid screenshots for the dialog entirely since its pretty self explanatory. 

I have also tried to explicitly avoid the words `workspace` and `project` in this doc except for one or two exceptions - but we may want to remove those as well.

In regards to the workspace switcher - I think we can cover this topic in the ui interface doc being worked on here: https://github.com/posit-dev/positron-website/pull/95 