### PR TITLE
Hide the UI page for now

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -60,7 +60,6 @@ website:
       style: "docked"
       contents:
         - add-to-path.qmd
-        - user-interface.qmd
         - section: "Interpreters"
           contents:
             - managing-interpreters.qmd


### PR DESCRIPTION
I think something went wrong with these commits which were applied to `main`:

https://github.com/posit-dev/positron-website/commits/main/user-interface.qmd

We have the PR open here for that same file:

https://github.com/posit-dev/positron-website/pull/95

For now, I am just taking the page out of the navigation so folks can't get to it.