### PR TITLE
Change "Run Interactive Apps" to "Develop Data Apps"

### DIFF
--- a/develop-data-apps.qmd
+++ b/develop-data-apps.qmd
@@ -1,8 +1,8 @@
 ---
-title: "Run Interactive Apps"
+title: "Develop Data Apps"
 ---
 
-Positron provides a simplified method for running interactive apps via the **Play** button. Instead of running an app from a **Terminal**, you can run supported apps by clicking the **Play** button in Editor Actions. Additionally, you can start a supported app in debug mode through the **Play** button context menu.
+Positron provides a simplified method for previewing interactive data apps via the **Play** button. Instead of running an app from a **Terminal**, you can run supported apps by clicking the **Play** button in Editor Actions. Additionally, you can start a supported app in debug mode through the **Play** button context menu.
 
 ![Positron App Launcher button in Editor Actions](images/run-app-button.png)
 
@@ -18,7 +18,7 @@ Currently, Positron supports the following Python app frameworks:
 - [Streamlit](https://streamlit.io/)
 
 
-## Running an interactive app
+## Running a data app
 
 1. Open the `.py` file of a supported app framework.
 2. In Editor Actions, click **Play**.
@@ -32,7 +32,7 @@ If your application does not automatically open in the Viewer, check that the se
 
 To stop the app, select the **Terminal** tab running the application and use the trash can icon to delete the **Terminal** or press {{< kbd Ctrl-C >}} to stop the process.
 
-## Debugging an interactive app
+## Debugging a data app
 
 1. Open the `.py` file of a supported app framework.
 2. Set breakpoints in the `.py` file by clicking on the editor margin.


### PR DESCRIPTION
I propose updating some of the copy about running interactive apps to specify "data apps", which is becoming industry standard terminology, e.g.:
- Dash: "Dash is the original low-code framework for rapidly building data apps in Python."
- Streamlit: "A faster way to build and share data apps"
- Databricks Apps: "Quickly build secure data and AI apps"

I personally find myself searching for "data apps" on the documentation website and having to remind myself we currently say "interactive apps". I believe this change would help more users find this section of our docs.