### PR TITLE
Updates site CSS to specify a new FA font family name

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 /* css styles */
 @font-face {
-  font-family: 'Font Awesome 6 Free';
+  font-family: 'Font Awesome 6 Free - Positron';
   font-style: normal;
   font-weight: 900;
   font-display: block;
@@ -10,5 +10,5 @@
 /* Add gear icon before links with href starting with "positron://settings" */
 a[href^="positron://settings"]::before {
   content: "\f013"; /* Unicode for gear in Font Awesome */
-  font-family: 'Font Awesome\ 6 Free'; 
+  font-family: 'Font Awesome\ 6 Free - Positron';
 }


### PR DESCRIPTION
The `quarto-ext` extension provides the `{{< fa ... >}}` shortcode, which when invoked, creates a font family that conflicts with the FontAwesome definition from the site's CSS file.

See:
[styles.css](https://github.com/posit-dev/positron-website/blob/aaa57efc9069b8684135f1e68baff622ceab4665/styles.css#L3) vs. [_extensions/quarto-ext/fontawesome/assets/css/all.css](https://github.com/posit-dev/positron-website/blob/aaa57efc9069b8684135f1e68baff622ceab4665/_extensions/quarto-ext/fontawesome/assets/css/all.css#L7970)

Addresses [#8422](https://github.com/posit-dev/positron/issues/8422)