### PR TITLE
Turn off external link icons throughout the site

### DIFF
--- a/_extensions/posit-dev/posit-docs/_extension.yml
+++ b/_extensions/posit-dev/posit-docs/_extension.yml
@@ -23,7 +23,7 @@ contributes:
         highlight-style: 
           light: github
           # dark: arrow
-        link-external-icon: true
+        # link-external-icon: true
         link-external-newwindow: true
         code-copy: true
         toc: true


### PR DESCRIPTION
Now that we've got the new theme all updated, let's turn off those external link icons on this site.