### PR TITLE
Switch to the "neutral" mermaid theme temporarily

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -98,4 +98,6 @@ website:
 format:
   html:
     css: styles.css
+    mermaid: 
+      theme: neutral
     link-external-filter: '^(?:http:|https:)\/\/(?:positron|cdn)\.posit\.co(?:\/|$)|^(?:http:|https:)\/\/.*--positron-posit-co\.netlify\.app(?:\/|$)|^(?!https?:\/\/)'


### PR DESCRIPTION
After we applied the new theme, the mermaid diagrams do not render well:

<img width="986" height="648" alt="Screenshot 2025-07-30 at 6 57 43 PM" src="https://github.com/user-attachments/assets/4712bed0-a945-4f04-b846-46177a267ae5" />

Just until we can get this straightened out, let's go with the dead boring "neutral" theme, which is at least readable. 😅 