### PR TITLE
Fix redirect rstudio-rproj-file change to .html 

### DIFF
--- a/migrate-rstudio-rproj.qmd
+++ b/migrate-rstudio-rproj.qmd
@@ -1,7 +1,7 @@
 ---
 title: "The Rproj File"
 aliases:
-  - rstudio-rproj-file.qmd
+  - rstudio-rproj-file.html
 ---
 
 <!-- vale Posit.Contractions = NO -->


### PR DESCRIPTION
Currently the redirect is not working from 
Old: https://positron.posit.co/rstudio-rproj-file.html  (broken) 

New: https://positron.posit.co/migrate-rstudio-rproj.html (working)

Change to .html per the docs 
https://quarto.org/docs/websites/website-navigation.html#redirects 
<img width="657" height="246" alt="Screenshot 2025-08-25 at 1 44 49 PM" src="https://github.com/user-attachments/assets/cacc3bc0-39fc-4f59-b0d7-54e40b76d350" />
