### PR TITLE
remove button styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -24,10 +24,6 @@ nav .nav-item:not(.compact) {
   width: auto;
 }
 
-#top-bar-download-btn {
-  margin-top: -7px
-}
-
 /* Keyboard shortcuts */
 kbd {
     padding: .2rem .4rem;


### PR DESCRIPTION
Fix alignment of the nav bar so that the text for Positron is bottom aligned with the nav links i.e. Positron, Features, Download, etc. 

Fix: remove unnecessary styling for #top-bar-download-btn

Without changes
<img width="1230" height="60" alt="Screenshot 2025-09-10 at 9 18 53 AM" src="https://github.com/user-attachments/assets/2ebdd1f4-a562-4b0f-b865-d86d6d361250" />

With changes:

<img width="1224" height="50" alt="Screenshot 2025-09-10 at 9 18 35 AM" src="https://github.com/user-attachments/assets/8f9193cc-00db-4aca-be7b-e958e39cf337" />
