### PR TITLE
fix url ref due to nesting styles.css under css/

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4,7 +4,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: block;
-  src: url("_extensions/quarto-ext/fontawesome/assets/webfonts/fa-solid-900.woff2");
+  src: url("../_extensions/quarto-ext/fontawesome/assets/webfonts/fa-solid-900.woff2");
 }
 
 /* Add gear icon before links with href starting with "positron://settings" */


### PR DESCRIPTION
See [thread](https://positpbc.slack.com/archives/C04FPQK3H9C/p1758201865861269)

Because I moved styles.css under css/, I need to update any url references within the styles.css sheet.  This is causing icons not to load .

Local changes show the icon appearing:
<img width="569" height="175" alt="Screenshot 2025-09-18 at 2 46 57 PM" src="https://github.com/user-attachments/assets/3e54876f-679a-4ffe-8801-1796deeb3a50" />
