### PR TITLE
An attempt to theme the mermaid diagrams

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -127,6 +127,4 @@ website:
 format:
   html:
     css: css/styles.css
-    mermaid: 
-      theme: neutral
     link-external-filter: '^(?:http:|https:)\/\/(?:positron|cdn)\.posit\.co(?:\/|$)|^(?:http:|https:)\/\/.*--positron-posit-co\.netlify\.app(?:\/|$)|^(?!https?:\/\/)'

--- a/css/styles.css
+++ b/css/styles.css
@@ -50,6 +50,13 @@ kbd {
   margin-right: 5px;
 }
 
+/* Mermaid diagram customization */
+:root {
+  --mermaid-label-fg-color: #3a78b1; /* positron-blue for text color */
+  --mermaid-node-bg-color: #e6eef6;  /* Light blue to go with positron-blue */
+  --mermaid-fg-color--lightest: #f9f9fb; /* Very light gray for cluster backgrounds */
+}
+
 /* Custom card styling */
 
 /* Custom card grid - responsive layout (Welcome page - 3 columns) */

--- a/css/styles.css
+++ b/css/styles.css
@@ -50,11 +50,39 @@ kbd {
   margin-right: 5px;
 }
 
-/* Mermaid diagram customization */
-:root {
-  --mermaid-label-fg-color: #3a78b1; /* positron-blue for text color */
-  --mermaid-node-bg-color: #e6eef6;  /* Light blue to go with positron-blue */
-  --mermaid-fg-color--lightest: #f9f9fb; /* Very light gray for cluster backgrounds */
+/* Target all Mermaid diagrams */
+[id^="mermaid-"] .cluster rect {
+  fill: #f9f9fb !important;
+  stroke: #213d4f !important; /* posit-dark-blue-2 */
+}
+
+[id^="mermaid-"] .node rect {
+  fill: #e6eef6 !important;
+  stroke: #213d4f !important; /* posit-dark-blue-2 */
+}
+
+[id^="mermaid-"] .nodeLabel {
+  fill: #213d4f !important; /* posit-dark-blue-2 */
+}
+
+[id^="mermaid-"] .edgeLabel p {
+  color: #213d4f !important; /* posit-dark-blue-2 */
+}
+
+[id^="mermaid-"] foreignObject:has(.edgeLabel) {
+    background-color: #f9f9fb !important;
+    border-radius: 8px;
+}
+
+[id^="mermaid-"] p {
+    margin-inline: auto !important;
+    max-width: max-content;
+    border-radius: 8px;
+    padding: 0 0.75rem;
+}
+
+[id^=mermaid-] .labelBkg {
+    background-color: transparent !important;
 }
 
 /* Custom card styling */


### PR DESCRIPTION
@AshleyHenry15 I played around with this a bit tonight and came up with this, which does work. What is good about this option is:

- the text is still big enough relative to the rest of the page
- we can read the text against the background of the diagram shapes

What do you think about controlling the mermaid diagram look this way? Could we use this type of CSS in the theme itself, or is it better to take this approach?