### PR TITLE
add docs about publishing to connect

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -90,6 +90,7 @@ website:
             - quarto.qmd
             - jupyter-notebooks.qmd
             - develop-data-apps.qmd
+            - publishing-to-connect.qmd
         - section: "Workspaces"
           contents:
             - folder-templates.qmd

--- a/extensions.qmd
+++ b/extensions.qmd
@@ -45,7 +45,7 @@ Some examples of the bootstrapped extensions include:
 
 - [ms-pyright.pyright](https://open-vsx.org/extension/ms-pyright/pyright): A fast Python static type checker and language server. It provides intelligent code completion, type checking, and helps catch errors before runtime.
 
-- [posit.publisher](https://open-vsx.org/extension/posit/publisher): A publishing tool for deploying content to Posit Connect. It streamlines the process of sharing data science applications, reports, and APIs with stakeholders.
+- [posit.publisher](https://open-vsx.org/extension/posit/publisher): A publishing tool for deploying content to Posit Connect. It streamlines the process of sharing data science applications, reports, and APIs with stakeholders. Explore the [publisher guide](publishing-to-connect.qmd)
 
 - [quarto.quarto](https://open-vsx.org/extension/quarto/quarto): Support for the Quarto publishing system. It enables creation of dynamic documents that combine code, visualizations, and narrative text for reproducible research and reporting.
 

--- a/features.qmd
+++ b/features.qmd
@@ -65,6 +65,10 @@ listing:
       - title: "Multi-session console"
         description: "Work across one or multiple consoles for concurrent analysis and development."
         icon: "bi-terminal"
+      - title: "Publish reports in seconds"
+        description: "With a click of a button, seamlessly deploy your project to share using Posit Publisher to Posit Connect"
+        icon: "bi-upload"
+        anchor-text: "Publish reports in seconds"
         
 ---
 

--- a/publishing-to-connect.qmd
+++ b/publishing-to-connect.qmd
@@ -1,0 +1,44 @@
+---
+title: "Publishing your work"
+description: "Publish your data science work from Positron to Posit Connect and Posit Connect Cloud using the built-in Publisher extension."
+meta-description: "Publish Quarto documents, Shiny apps, Jupyter notebooks, and APIs from Positron to Posit Connect with one-click deployment using the Publisher extension."
+---
+
+Publish your data science work directly from Positron to [Posit Connect](https://posit.co/products/enterprise/connect/) and [Posit Connect Cloud](https://connect.posit.cloud/) with the built-in [Publisher extension](https://open-vsx.org/extension/posit/publisher).
+
+Whether you're sharing reports, applications, or APIs, the Publisher extension streamlines the deployment process and makes it easy to get your work in front of stakeholders quickly with a button click.
+
+{{< video videos/deploy-to-connect.mp4 aria-label="Positron Publisher extension demonstrating one-click deployment to Posit Connect" >}}
+
+## Getting started with Publisher
+
+The [Posit Publisher extension](https://open-vsx.org/extension/posit/publisher) comes pre-installed with Positron as a bootstrapped extension. This means it's automatically available when you start Positron and updates automatically when new versions are released.
+
+## What you can publish
+
+The Publisher extension supports a wide range of content types including:
+
+- **Quarto documents** - Dynamic reports and presentations
+- **Jupyter notebooks** - Interactive data analysis notebooks
+- **Shiny applications** - Interactive web applications
+- **Plumber APIs** - RESTful APIs for data services
+- **R Markdown documents** - Reproducible reports
+- **Static websites** - HTML, CSS, and JavaScript projects
+
+For a full list of supported files, view the [publisher documentation](https://github.com/posit-dev/publisher/blob/main/docs/configuration.md).
+
+## Publishing workflow
+
+1. Ensure your project is ready for publication
+
+2. In the Activty Bar, select the Publisher icon.
+3. Select the type of content you're publishing
+4. Choose your target Posit Connect server
+5. Configure any deployment settings
+6. Add your API credentials
+7. Click "Publish"
+
+### Getting help
+- See the [troubleshooting guide](https://github.com/posit-dev/publisher/blob/main/docs/troubleshooting.md)
+- Check the [Posit Connect documentation](https://docs.posit.co/connect/) for server-specific guidance
+- Review the [Publisher extension repository](https://github.com/posit-dev/publisher) for updates and issues

--- a/videos/deploy-to-connect.mp4
+++ b/videos/deploy-to-connect.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5866af19122b723f7df61f4cc5a406639996636ac965b8cc6a18960ecf57c76b
+size 6722546


### PR DESCRIPTION
We currently do not surface the existing functionality to publish to connect well.  Based on convos with @kellobri, we want to highlight this better in Positron.

This pr
- adds a doc on publishing to connect to /guides
- adds this feature to /features 
- includes a video showing the publish flow  